### PR TITLE
fw upload fix for bins larger than 0xE500+ auto reboot after fw upload

### DIFF
--- a/k5prog.c
+++ b/k5prog.c
@@ -651,7 +651,7 @@ int k5_send_flash_version_message(int fd) {
 	return(1);
 }
 
-int k5_writeflash(int fd, unsigned char *buf, int  len, int offset)
+int k5_writeflash(int fd, unsigned char *buf, int  len, int offset, int fw_size_blocks)
 {
 	int l;
 	unsigned char writeflash[512];
@@ -679,7 +679,7 @@ int k5_writeflash(int fd, unsigned char *buf, int  len, int offset)
 
 	writeflash[8]=(offset>>8)&0xff;
 	writeflash[9]=offset&0xff;
-	writeflash[10]=0xe6;
+	writeflash[10]=fw_size_blocks&0xff; // bootloader probably uses this to determinate total fw len (in flash pages)
 	writeflash[11]=0x00;
 	writeflash[12]=len&0xff;
 	writeflash[13]=(len>>8)&0xff;
@@ -1033,7 +1033,7 @@ int main(int argc,char **argv)
 				len=flash_length-i;
 				if (len>UVK5_FLASH_BLOCKSIZE) len=UVK5_FLASH_BLOCKSIZE;
 
-				r=k5_writeflash(fd, (unsigned char *)&flash+i,len,i);
+				r=k5_writeflash(fd, (unsigned char *)&flash+i,len,i,(flash_length+0xFF)/0x100);
 
 				printf("*** FLASH at 0x%4.4x length 0x%4.4x  result=%i\n",i,len,r);
 				if (!r) {


### PR DESCRIPTION
![image](https://github.com/sq5bpf/k5prog/assets/17248077/8fe7b9ea-8f97-4e50-aac4-8e44174f1897)  
found that this magic byte is used by bootloader to determinate total size of fw in flash pages, and boot to main fw after receiving num of packets determined by this value. So previously when flashing bins larger than 0xE500, bootloader was jumping to main fw before all fw packets has been sent