### PR TITLE
Reduce arbitrary flash size limit so LTO'd builds can be flashed

### DIFF
--- a/k5prog.c
+++ b/k5prog.c
@@ -1007,7 +1007,8 @@ int main(int argc,char **argv)
 			close(ffd);
 
 			/* arbitrary limit do that someone doesn't flash some random short file */
-			if (flash_length<50000) {
+			/* reduced from 50k as LTO builds can be smaller and fail this check */
+			if (flash_length<40000) {
 				fprintf(stderr,"Failed to read whole eeprom from file %s (read %i), file too short or some other error\n",file,flash_length);
 				exit(1);
 			}


### PR DESCRIPTION
With the introduction of link-time optimisation (LTO), some default builds of OEFW may be smaller than the current 50k minimum size. This PR seeks to lower it to 40k, unless a better way to determine users aren't trying to flash random files is preferred.