### PR TITLE
Set both `cfsetospeed` and `cfsetispeed`

### DIFF
--- a/k5prog.c
+++ b/k5prog.c
@@ -199,6 +199,7 @@ int openport(char *port,speed_t speed)
 	my_termios.c_cflag =  CS8 |CREAD | CLOCAL | HUPCL;
 	cfmakeraw(&my_termios);
 	cfsetospeed(&my_termios, speed);
+	cfsetispeed(&my_termios, speed);
 	if (	tcsetattr(fd, TCSANOW, &my_termios))
 	{
 		printf("tcsetattr error %d %s\n", errno, strerror(errno));


### PR DESCRIPTION
Trying to run the executable on MacOS with a Baofeng cable results in:
```
> ./k5prog -p /dev/cu.usbserial-110 -r
Quansheng UV-K5 EEPROM programmer v0.9 (c) 2023 Jacek Lipkowski <sq5bpf@lipkowski.org>

tcsetattr error 22 Invalid argument
Open /dev/cu.usbserial-110 failed
```

Setting both the output and input baud rate fixes the problem.