### PR TITLE
Drop timeout on sync.

### DIFF
--- a/k5prog.c
+++ b/k5prog.c
@@ -439,7 +439,7 @@ struct k5_command *k5_receive(int fd,int tmout) {
         /* Assume we are out of sync and flush rx buffer by reading everything.
          * This works because the boot message is repeated. */
         while (len>0)
-            len =read_timeout(fd,(unsigned char *)&buf,sizeof(buf),10000);
+            len =read_timeout(fd,(unsigned char *)&buf,sizeof(buf),0);
         return(0);
     }
 


### PR DESCRIPTION
When out of sync all bytes must be drained at once in order to be able to reach sync again. This strategy works because the radio will repeatedly send the bootmessage. We do not need to save bytes and try to sync up based on bytes, just drop all received bytes and wait for the radio to send a new bootmessage.

If we wait 10 seconds (or any time longer then the boot message repeat time) we will read garbage from the previous package, discard those and the rest of the message and we will never reach sync.